### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -5,7 +5,7 @@ on:
       custom_gluetun_version:
         description: 'Set a version of Gluetun to test against'
         required: false
-        default: v3.39
+        default: latest
       tmate_enabled:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,9 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Test against Gluetun v3.36
-      run: make GLUETUN_VERSION=v3.36 pr-test
-
     - name: Test against Gluetun v3.37
       run: make GLUETUN_VERSION=v3.37 pr-test
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,6 +14,17 @@ on:
   workflow_dispatch:
   schedule:
       - cron: "0 6 * * *"
+
+env:
+  GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+  GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+  GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+  GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+  GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+  GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+  GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
 jobs:
   lint-docker:
     runs-on: ubuntu-latest
@@ -28,32 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@2.0.0
 
-  pr-check-against-latest:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Test against Gluetun latest
-      run: make GLUETUN_VERSION=latest pr-test
-
   pr-check-against-3-37:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -61,15 +47,6 @@ jobs:
       run: make GLUETUN_VERSION=v3.37 pr-test
 
   pr-check-against-3-37-1:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -77,15 +54,6 @@ jobs:
       run: make GLUETUN_VERSION=v3.37.1 pr-test
 
   pr-check-against-3-38:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -93,15 +61,6 @@ jobs:
       run: make GLUETUN_VERSION=v3.38 pr-test
 
   pr-check-against-3-38-1:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -109,15 +68,6 @@ jobs:
       run: make GLUETUN_VERSION=v3.38.1 pr-test
 
   pr-check-against-3-39:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -125,17 +75,22 @@ jobs:
       run: make GLUETUN_VERSION=v3.39 pr-test
 
   pr-check-against-3-39-1:
-    env:
-      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
-      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
-      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
-      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
-      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
-      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
-      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Test against Gluetun v3.39.1
       run: make GLUETUN_VERSION=v3.39.1 pr-test
+
+  pr-check-against-3-40-0:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test against Gluetun v3.40.0
+      run: make GLUETUN_VERSION=v3.40.0 pr-test
+
+  pr-check-against-latest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test against Gluetun latest
+      run: make GLUETUN_VERSION=latest pr-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Test against Gluetun v3.37
+      securityContext:
+        privileged: true
       run: make GLUETUN_VERSION=v3.37 pr-test
 
     - name: Test against Gluetun v3.37.1

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,7 +28,23 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@2.0.0
 
-  pr-check-against-supported-gluetun-versions:
+  pr-check-against-latest:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test against Gluetun latest
+      run: make GLUETUN_VERSION=latest pr-test
+
+  pr-check-against-3-37:
     env:
       GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
       GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
@@ -42,24 +58,84 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Test against Gluetun v3.37
-      securityContext:
-        privileged: true
       run: make GLUETUN_VERSION=v3.37 pr-test
 
+  pr-check-against-3-37-1:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Test against Gluetun v3.37.1
       run: make GLUETUN_VERSION=v3.37.1 pr-test
 
+  pr-check-against-3-38:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Test against Gluetun v3.38
       run: make GLUETUN_VERSION=v3.38 pr-test
 
+  pr-check-against-3-38-1:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Test against Gluetun v3.38.1
       run: make GLUETUN_VERSION=v3.38.1 pr-test
 
+  pr-check-against-3-39:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Test against Gluetun v3.39
       run: make GLUETUN_VERSION=v3.39 pr-test
 
+  pr-check-against-3-39-1:
+    env:
+      GLUETRANS_VPN_USERNAME: ${{ secrets.GLUETRANS_VPN_USERNAME }}
+      GLUETRANS_VPN_PASSWORD: ${{ secrets.GLUETRANS_VPN_PASSWORD }}
+      GLUETRANS_VPN_REGIONS: ${{ secrets.GLUETRANS_VPN_REGIONS }}
+      GLUETRANS_TRANSMISSION_USERNAME: ${{ secrets.GLUETRANS_TRANSMISSION_USERNAME }}
+      GLUETRANS_TRANSMISSION_PASSWORD: ${{ secrets.GLUETRANS_TRANSMISSION_PASSWORD }}
+      GLUETRANS_SONAR_ORGANIZATION: ${{ secrets.GLUETRANS_SONAR_ORGANIZATION }}
+      GLUETRANS_SONAR_PROJECT_KEY: ${{ secrets.GLUETRANS_SONAR_PROJECT_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
     - name: Test against Gluetun v3.39.1
       run: make GLUETUN_VERSION=v3.39.1 pr-test
-
-    - name: Test against Gluetun latest
-      run: make GLUETUN_VERSION=latest pr-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,8 @@ on:
       - edited
       - synchronize
   workflow_dispatch:
-
+  schedule:
+      - cron: "0 6 * * *"
 jobs:
   lint-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -58,5 +58,8 @@ jobs:
     - name: Test against Gluetun v3.39
       run: make GLUETUN_VERSION=v3.39 pr-test
 
+    - name: Test against Gluetun v3.39.1
+      run: make GLUETUN_VERSION=v3.39.1 pr-test
+
     - name: Test against Gluetun latest
       run: make GLUETUN_VERSION=latest pr-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Alpine Linux as the base image
-FROM alpine:3.20.3
+FROM alpine:3.21.0
 
 # required env vars
 ENV GLUETUN_ENDPOINT=$GLUETUN_ENDPOINT
@@ -9,7 +9,7 @@ ENV TRANSMISSION_PASS=$TRANSMISSION_PASS
 ENV PEERPORT_CHECK_INTERVAL=$PEERPORT_CHECK_INTERVAL
 
 # install packages
-RUN apk add --no-cache transmission-remote=4.0.5-r2 jq=1.7.1-r0 bash=5.2.26-r0 curl=8.10.1-r0
+RUN apk add --no-cache transmission-remote=4.0.6-r0 jq=1.7.1-r0 bash=5.2.37-r0 curl=8.11.0-r2
 
 # copy script to container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use Alpine Linux as the base image
-FROM alpine:3.21.0
+FROM alpine:3.21.2
 
 # required env vars
 ENV GLUETUN_ENDPOINT=$GLUETUN_ENDPOINT
@@ -9,7 +9,7 @@ ENV TRANSMISSION_PASS=$TRANSMISSION_PASS
 ENV PEERPORT_CHECK_INTERVAL=$PEERPORT_CHECK_INTERVAL
 
 # install packages
-RUN apk add --no-cache transmission-remote=4.0.6-r0 jq=1.7.1-r0 bash=5.2.37-r0 curl=8.11.0-r2
+RUN apk add --no-cache transmission-remote=4.0.6-r0 jq=1.7.1-r0 bash=5.2.37-r0 curl=8.11.1-r0
 
 # copy script to container
 COPY entrypoint.sh /entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ GHCR_REPO := ghcr.io/miklosbagi/gluetranspia
 DOCKER_BUILD_CMD := docker buildx build --platform linux/amd64,linux/arm64
 DOCKER_COMPOSE_CMD := docker compose -f test/docker-compose-build.yaml
 
-GLUETUN_VERSION := v3.39
-TRANSMISSION_VERSION := 4.0.5
+GLUETUN_VERSION := v3.40.0
+TRANSMISSION_VERSION := 4.0.6
 SANITIZE_LOGS := 0
 
 GLUETRANS_VPN_USERNAME := $(shell echo $$GLUETRANS_VPN_USERNAME)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ services:
       VPN_PORT_FORWARDING: on
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
     restart: unless-stopped
+    devices:
+      - /dev/net/tun:/dev/net/tun
 
   transmission:
     image: linuxserver/transmission:4.0.5

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Also, please note that we test against versions, not :latest, as that's like a w
 ```
 services:
   gluetun:
-    image: qmcgaw/gluetun:v3.37.0
+    image: qmcgaw/gluetun:v3.40.0
     volumes:
       - ./data/gluetun:/gluetun
     cap_add:
@@ -105,7 +105,7 @@ services:
       - /dev/net/tun:/dev/net/tun
 
   transmission:
-    image: linuxserver/transmission:4.0.5
+    image: linuxserver/transmission:4.0.6
     environment:
       USER: My Transmission Username
       PASS: My Transmission Password

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,8 +125,8 @@ check_transmission_port_open() {
 pick_new_gluetun_server() {
     log "asking gluetun to disconnect from $country_details", "s#$country_details#* OMITTED *#"
     gluetun_server_response=$(curl -s -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
-    if [ "$gluetun_server_response" != '{"outcome":"stopped"}' ]; then
-        log "bleh, gluetun server response is weird, expected {\"outcome\":\"stopped\"}, got $gluetun_server_response"
+    if echo "$gluetun_server_response" | grep -qE '{"outcome":"(stopping|stopped)"}'; then
+        log "bleh, gluetun server response is weird, expected {\"outcome\":\"stopping\"}, got $gluetun_server_response"
         return 1
     fi    
     # this is fixed as ~ around this time it takes for gluetun to reconnect, this avoids some nag in logs

--- a/test/docker-compose-build.yaml
+++ b/test/docker-compose-build.yaml
@@ -14,6 +14,8 @@ services:
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: protonvpn
     restart: unless-stopped
+  devices:
+    - /dev/net/tun:/dev/net/tun
 
   transmission:
     image: linuxserver/transmission:${TRANSMISSION_VERSION}

--- a/test/docker-compose-build.yaml
+++ b/test/docker-compose-build.yaml
@@ -14,8 +14,8 @@ services:
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: protonvpn
     restart: unless-stopped
-  devices:
-    - /dev/net/tun:/dev/net/tun
+    devices:
+      - /dev/net/tun:/dev/net/tun
 
   transmission:
     image: linuxserver/transmission:${TRANSMISSION_VERSION}


### PR DESCRIPTION
- transmission-remote to 4.0.6-r0
- bash to 5.2.37-r0 
- curl to 8.11.0-r2
- gluetun v3.39.1 added for testgs
- gluetun v3.36 removed from tests as it's over a year old

Also this is adding nightly runs