### PR TITLE
fix: add timeouts to avoid long script blocks (issue #89)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ DOCKER_COMPOSE_CMD := docker compose -f test/docker-compose-build.yaml
 GLUETUN_VERSION := v3.41.0
 TRANSMISSION_VERSION := 4.0.6
 SANITIZE_LOGS := 0
+# Optional: FIX=89 make release-dev → tags dev-89 (Docker Hub + GHCR) for testing multiple dev builds
+DEV_TAG := dev$(if $(FIX),-$(FIX),)
 
 GLUETRANS_VPN_USERNAME := $(shell echo $$GLUETRANS_VPN_USERNAME)
 include test/.env
@@ -24,10 +26,10 @@ lint:
 	@hadolint Dockerfile && echo "✅ Dockerfile linting passed." || (echo "❌ Dockerfile linting failed." && exit 1)
 
 release-dev: test
-	@${DOCKER_BUILD_CMD} -t ${DOCKER_REPO}:dev --push . && echo "✅ Release dev built, tagged, and pushed to docker.io repo." || (echo "❌ Release dev failed to build docker repo package." && exit 1)
-	@docker pull ${DOCKER_REPO}:dev && echo "✅ Release dev successfully pulled from docker.io repo." || (echo "❌ Release dev failed pulling back from docker repo." && exit 1)
-	@docker tag ${DOCKER_REPO}:dev ${GHCR_REPO}:dev && echo "✅ Release dev tagged for ghcr repo." || (echo "❌ Release dev tagging for ghcr repo." && exit 1)
-	@docker push ${GHCR_REPO}:dev && echo "✅ Release dev pushed to ghcr repo." || (echo "❌ Release dev failed pushing to ghcr repo." && exit 1)
+	@${DOCKER_BUILD_CMD} -t ${DOCKER_REPO}:$(DEV_TAG) --push . && echo "✅ Release $(DEV_TAG) built, tagged, and pushed to docker.io repo." || (echo "❌ Release $(DEV_TAG) failed to build docker repo package." && exit 1)
+	@docker pull ${DOCKER_REPO}:$(DEV_TAG) && echo "✅ Release $(DEV_TAG) successfully pulled from docker.io repo." || (echo "❌ Release $(DEV_TAG) failed pulling back from docker repo." && exit 1)
+	@docker tag ${DOCKER_REPO}:$(DEV_TAG) ${GHCR_REPO}:$(DEV_TAG) && echo "✅ Release $(DEV_TAG) tagged for ghcr repo." || (echo "❌ Release $(DEV_TAG) tagging for ghcr repo." && exit 1)
+	@docker push ${GHCR_REPO}:$(DEV_TAG) && echo "✅ Release $(DEV_TAG) pushed to ghcr repo." || (echo "❌ Release $(DEV_TAG) failed pushing to ghcr repo." && exit 1)
 
 release-latest: test
 	@${DOCKER_BUILD_CMD} -t ${DOCKER_REPO}:latest --push . && echo "✅ Release latest built, tagged, and pushed to docker.io repo." || (echo "❌ Release latest failed to build docker repo package." && exit 1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,9 +20,15 @@
 # Optional security/debugging env vars:
 # DEBUG: Set to 1 to keep sensitive env vars visible for debugging (default: 0)
 # SANITIZE_LOGS: Set to 1 to omit sensitive information from logs (default: 0)
+# Optional timeouts (issue #89): avoid long blocks when Gluetun/Transmission are slow
+# CURL_API_TIMEOUT: max seconds for curl to Gluetun API and country endpoints (default: 10)
+# RPC_TIMEOUT: max seconds for transmission-remote RPC calls (default: 15)
 GLUETUN_PICK_NEW_SERVER_AFTER=${GLUETUN_PICK_NEW_SERVER_AFTER:-10}
 PEERPORT_CHECK_INTERVAL=${PEERPORT_CHECK_INTERVAL:-15}
 STANDARD_WAIT_TIME=${STANDARD_WAIT_TIME:-5}
+# Timeouts for external calls to avoid long blocks (issue #89)
+CURL_API_TIMEOUT=${CURL_API_TIMEOUT:-10}
+RPC_TIMEOUT=${RPC_TIMEOUT:-15}
 
 FORCED_COUNTRY_JUMP=${FORCED_COUNTRY_JUMP:-0}
 FORCE_JUMP_INTERVAL=$((FORCED_COUNTRY_JUMP * 60))
@@ -66,7 +72,7 @@ get_connection_country() {
     retries=3
     for endpoint in "${endpoints[@]}"; do
         for ((i=0; i<retries; i++)); do
-            country=$(curl -s "$endpoint" | jq -r '.timezone' 2>&1) || country=$(curl -s "$endpoint" | jq -r '.time_zone' 2>&1)
+            country=$(curl -s -m "$CURL_API_TIMEOUT" "$endpoint" | jq -r '.timezone' 2>&1) || country=$(curl -s -m "$CURL_API_TIMEOUT" "$endpoint" | jq -r '.time_zone' 2>&1)
             if [[ $country != *"parse error"* ]]; then
                 echo "$country"
                 return 0
@@ -97,7 +103,7 @@ wait_for_gluetun() {
 
 # get transmission peer port
 get_transmission_port() {
-    transmission_response=$(transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -si | grep Listenport | awk -F' ' '{print $2}')
+    transmission_response=$(timeout "$RPC_TIMEOUT" transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -si | grep Listenport | awk -F' ' '{print $2}')
     if [ "$transmission_response" == "" ]; then
         log "tramsmission returned '$transmission_response', waiting for $gluetun_port to be picked up, retrying ($transmission_port_fail_count / $GLUETUN_PICK_NEW_SERVER_AFTER)...", "s#$gluetun_port#* OMITTED *#g"
         return 1
@@ -109,13 +115,13 @@ get_transmission_port() {
 # get peer port from vpn via gluetun control server
 get_gluetun_port() {
     # Try new API endpoint first (v3.41.0+)
-    gluetun_response=$(curl -s -H "X-API-Key: $_gluetun_api_key" "$GLUETUN_CONTROL_ENDPOINT/v1/portforward")
-    
+    gluetun_response=$(curl -s -m "$CURL_API_TIMEOUT" -H "X-API-Key: $_gluetun_api_key" "$GLUETUN_CONTROL_ENDPOINT/v1/portforward")
+
     # Check if new endpoint failed - fallback to old API for backward compatibility
     # Conditions: contains "not found", "Unauthorized", or doesn't have valid .port field
     if echo "$gluetun_response" | grep -iq "not found\|unauthorized" || ! echo "$gluetun_response" | jq -e '.port' >/dev/null 2>&1; then
         # Fallback to old API endpoint (v3.40.0 and older)
-        gluetun_response=$(curl -s -H "X-API-Key: $_gluetun_api_key" "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/portforwarded")
+        gluetun_response=$(curl -s -m "$CURL_API_TIMEOUT" -H "X-API-Key: $_gluetun_api_key" "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/portforwarded")
     fi
     
     if [ "$gluetun_response" == "" ] || [ "$gluetun_response" == '{"port":0}' ]; then
@@ -128,12 +134,12 @@ get_gluetun_port() {
 
 # get transmission peer port from rpc endpoint
 update_transmission_port() {
-    transmission_response=$(transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -p "$1") || return 1
+    transmission_response=$(timeout "$RPC_TIMEOUT" transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -p "$1") || return 1
 }
 
 # check if transmission port is open
 check_transmission_port_open() {
-    transmission_response=$(transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -pt) || return 1
+    transmission_response=$(timeout "$RPC_TIMEOUT" transmission-remote "$TRANSMISSION_ENDPOINT" -n "$_transmission_user":"$_transmission_pass" -pt) || return 1
     echo "$transmission_response"
 }
 
@@ -142,12 +148,12 @@ pick_new_gluetun_server() {
     log "asking gluetun to disconnect from $country_details", "s#$country_details#* OMITTED *#"
     
     # Try new API endpoint first (v3.41.0+)
-    gluetun_server_response=$(curl -s -H "X-API-Key: $_gluetun_api_key" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/vpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
-    
+    gluetun_server_response=$(curl -s -m "$CURL_API_TIMEOUT" -H "X-API-Key: $_gluetun_api_key" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/vpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
+
     # Check if new endpoint failed - fallback to old API for backward compatibility
     if echo "$gluetun_server_response" | grep -iq "not found\|unauthorized" || ! echo "$gluetun_server_response" | grep -qE '\{"outcome":"(stopping|stopped)"\}'; then
         # Fallback to old API endpoint (v3.40.0 and older)
-        gluetun_server_response=$(curl -s -H "X-API-Key: $_gluetun_api_key" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
+        gluetun_server_response=$(curl -s -m "$CURL_API_TIMEOUT" -H "X-API-Key: $_gluetun_api_key" -X PUT -d '{"status":"stopped"}' "$GLUETUN_CONTROL_ENDPOINT/v1/openvpn/status") || log "error instructing gluetun to pick new server ($gluetun_server_response)."
         
         if ! echo "$gluetun_server_response" | grep -qE '\{"outcome":"(stopping|stopped)"\}'; then
             log "bleh, gluetun server response is weird, expected one of {\"outcome\":\"stopping\"} or {\"outcome\":\"stopped\"}, got $gluetun_server_response"


### PR DESCRIPTION
## Summary

Addresses #89: apparent 30–65 second gaps in logs where the script appeared to do nothing. The container was not frozen (user confirmed with a tight loop in exec); the script was blocking in external calls with no timeouts.

## Cause

- **curl** to Gluetun control API and country endpoints had no `-m` (only the health check used a timeout).
- **transmission-remote** (RPC) had no timeout; when Transmission or the connection was slow, calls could block until kernel TCP timeout (~60+ s), producing the observed gaps, especially in the "waiting for transmission port to update" retry loop.

## Changes

- **CURL_API_TIMEOUT** (default 10 s): applied to all curl calls to Gluetun API and to country-detection endpoints.
- **RPC_TIMEOUT** (default 15 s): applied via `timeout` to every `transmission-remote` call (`get_transmission_port`, `update_transmission_port`, `check_transmission_port_open`).
- Both are configurable via env for tuning if needed.

## Testing

- `shellcheck entrypoint.sh` passes.
- This PR is for maintainer testing over a few days before merge; no behavioral change to success paths when services respond quickly.