### PR TITLE
fix: credentials via *_FILE + PID1 bash for exec env (#88)

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -16,8 +16,9 @@
 #   DOCKERHUB_USERNAME
 #   DOCKERHUB_TOKEN      (Docker Hub access token / PAT with read & write)
 #
-# If either Docker Hub secret is unset, the build-push job is skipped (configure both to publish
-# dev images to Docker Hub and GHCR).
+# Docker Hub secrets must be set as repository secrets (not only in environments). The job validates
+# them in the first step — do not use secrets.* in job-level `if` (GitHub can skip the job even when
+# secrets exist on same-repo pull_request).
 #
 # GHCR: GitHub forbids *naming* a repo secret GITHUB_* (reserved prefix). Use GH_TOKEN
 # for a PAT with write:packages (classic) or "Contents: read" + "Packages: write"
@@ -66,14 +67,23 @@ concurrency:
 jobs:
   build-push:
     if: |
-      secrets.DOCKERHUB_USERNAME != '' &&
-      secrets.DOCKERHUB_TOKEN != '' &&
-      ((github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false) ||
-      (github.event_name == 'workflow_dispatch'))
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
+      - name: Require Docker Hub repository secrets
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo '::error::Set repository secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (Settings → Secrets and variables → Actions). Environment-only secrets are not visible to this workflow unless you add an environment: block.'
+            exit 1
+          fi
+
       - name: Resolve PR head SHA
         id: head
         env:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,9 +1,8 @@
 # Dev / preview images for PRs to main (same-repo only).
 #
-# Tags (Docker Hub + GHCR):
+# Tags (GHCR always; Docker Hub when secrets are set):
 #   - dev-v<VERSION file>-<7-char-sha> — unique per commit (e.g. dev-v0.3.8-a1b2c3d); see repo root VERSION
-#   - dev — rolling tag; always points at the **last successful** build from this workflow
-#     (same digest as that run’s unique tag). Last PR build wins if several PRs run close together.
+#   - dev — rolling tag on each registry we push to; same digest as that run’s unique tag for that registry.
 #
 # Triggers:
 #   - pull_request (opened, synchronize, reopened, ready_for_review): **synchronize** runs on
@@ -13,12 +12,9 @@
 #
 # Production v* and :latest are pushed by docker-release.yml when you push a semver tag after merge.
 #
-# Required repository secrets (Settings → Secrets and variables → Actions):
-#   DOCKERHUB_USERNAME
-#   DOCKERHUB_TOKEN      (Docker Hub access token / PAT with read & write)
-#
-# If DOCKERHUB_USERNAME or DOCKERHUB_TOKEN is unset, the build-push job is skipped so PR checks
-# still pass; add both secrets to enable dev image pushes.
+# Optional Docker Hub (Settings → Secrets and variables → Actions):
+#   DOCKERHUB_USERNAME + DOCKERHUB_TOKEN — when both are set, the same dev tags are also pushed to
+#   docker.io. When unset, the workflow still builds and pushes **GHCR only** (no extra secrets).
 #
 # GHCR: GitHub forbids *naming* a repo secret GITHUB_* (reserved prefix). Use GH_TOKEN
 # for a PAT with write:packages (classic) or "Contents: read" + "Packages: write"
@@ -67,12 +63,10 @@ concurrency:
 jobs:
   build-push:
     if: |
-      secrets.DOCKERHUB_USERNAME != '' &&
-      secrets.DOCKERHUB_TOKEN != '' &&
-      ((github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false) ||
-      (github.event_name == 'workflow_dispatch'))
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR head SHA
@@ -120,6 +114,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -137,6 +132,7 @@ jobs:
         id: meta
         env:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
+          PUSH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         run: |
           set -euo pipefail
           SHORT=$(echo "$HEAD_SHA" | cut -c1-7)
@@ -152,9 +148,15 @@ jobs:
           DOCKERHUB_IMG="docker.io/${REPO_LC}"
           GHCR_IMG="ghcr.io/${REPO_LC}"
 
-          TAGS="${DOCKERHUB_IMG}:${DEV_TAG}"$'\n'"${GHCR_IMG}:${DEV_TAG}"
-          TAGS+=$'\n'"${DOCKERHUB_IMG}:dev"
-          TAGS+=$'\n'"${GHCR_IMG}:dev"
+          if [ "${PUSH_DOCKERHUB}" = "true" ]; then
+            TAGS="${DOCKERHUB_IMG}:${DEV_TAG}"$'\n'"${GHCR_IMG}:${DEV_TAG}"
+            TAGS+=$'\n'"${DOCKERHUB_IMG}:dev"
+            TAGS+=$'\n'"${GHCR_IMG}:dev"
+          else
+            TAGS="${GHCR_IMG}:${DEV_TAG}"
+            TAGS+=$'\n'"${GHCR_IMG}:dev"
+            echo '::notice::Docker Hub credentials not set — publishing dev image to GHCR only. Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to also push docker.io tags.'
+          fi
 
           REPO_NAME=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
           LINK_DH="https://hub.docker.com/r/${REPO_LC}/tags?name=${DEV_TAG}"
@@ -162,6 +164,7 @@ jobs:
 
           echo "dev_tag=${DEV_TAG}" >> "$GITHUB_OUTPUT"
           echo "repo_lc=${REPO_LC}" >> "$GITHUB_OUTPUT"
+          echo "push_dockerhub=${PUSH_DOCKERHUB}" >> "$GITHUB_OUTPUT"
           echo "link_dockerhub=${LINK_DH}" >> "$GITHUB_OUTPUT"
           echo "link_ghcr=${LINK_GHCR}" >> "$GITHUB_OUTPUT"
           {
@@ -185,6 +188,7 @@ jobs:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
           DEV_TAG: ${{ steps.meta.outputs.dev_tag }}
           REPO_LC: ${{ steps.meta.outputs.repo_lc }}
+          PUSH_DOCKERHUB: ${{ steps.meta.outputs.push_dockerhub }}
           LINK_DH: ${{ steps.meta.outputs.link_dockerhub }}
           LINK_GHCR: ${{ steps.meta.outputs.link_ghcr }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -199,23 +203,32 @@ jobs:
             const sha = process.env.HEAD_SHA;
             const devTag = process.env.DEV_TAG;
             const repoLc = process.env.REPO_LC;
+            const pushDh = process.env.PUSH_DOCKERHUB === 'true';
             const linkDh = process.env.LINK_DH;
             const linkGhcr = process.env.LINK_GHCR;
             const runUrl = process.env.RUN_URL;
             const commitUrl = process.env.COMMIT_URL;
             const { owner, repo } = context.repo;
             const short = sha.slice(0, 7);
+            const table = [
+              '| Registry | Pull |',
+              '|----------|------|',
+            ];
+            if (pushDh) {
+              table.push(`| **Docker Hub** | [\`docker.io/${repoLc}:${devTag}\`](${linkDh}) |`);
+            }
+            table.push(`| **GHCR** | [\`ghcr.io/${repoLc}:${devTag}\`](${linkGhcr}) |`);
+            const rolling = pushDh
+              ? `**Unique tag:** \`${devTag}\` — **rolling \`dev\`** (same digest as this build): \`docker.io/${repoLc}:dev\` and \`ghcr.io/${repoLc}:dev\`.`
+              : `**Unique tag:** \`${devTag}\` — **rolling \`dev\` on GHCR:** \`ghcr.io/${repoLc}:dev\` (add \`DOCKERHUB_USERNAME\` + \`DOCKERHUB_TOKEN\` to also publish \`docker.io\`).`;
             const body = [
               '### Dev Docker image',
               '',
               `**Multi-arch** (\`linux/amd64\`, \`linux/arm64\`) for commit [\`${short}\`](${commitUrl})`,
               '',
-              '| Registry | Pull |',
-              '|----------|------|',
-              `| **Docker Hub** | [\`docker.io/${repoLc}:${devTag}\`](${linkDh}) |`,
-              `| **GHCR** | [\`ghcr.io/${repoLc}:${devTag}\`](${linkGhcr}) |`,
+              ...table,
               '',
-              `**Unique tag:** \`${devTag}\` — **rolling \`dev\`** (same digest as this build): \`docker.io/${repoLc}:dev\` and \`ghcr.io/${repoLc}:dev\`.`,
+              rolling,
               '',
               `[Workflow run](${runUrl})`,
             ].join('\n');

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,8 +1,8 @@
 # Dev / preview images for PRs to main (same-repo only).
 #
-# Tags (GHCR always; Docker Hub when secrets are set):
+# Tags (Docker Hub + GHCR for every successful run):
 #   - dev-v<VERSION file>-<7-char-sha> — unique per commit (e.g. dev-v0.3.8-a1b2c3d); see repo root VERSION
-#   - dev — rolling tag on each registry we push to; same digest as that run’s unique tag for that registry.
+#   - dev — rolling tag on each registry; same digest as that run’s unique tag. Last PR build wins on :dev.
 #
 # Triggers:
 #   - pull_request (opened, synchronize, reopened, ready_for_review): **synchronize** runs on
@@ -12,9 +12,12 @@
 #
 # Production v* and :latest are pushed by docker-release.yml when you push a semver tag after merge.
 #
-# Optional Docker Hub (Settings → Secrets and variables → Actions):
-#   DOCKERHUB_USERNAME + DOCKERHUB_TOKEN — when both are set, the same dev tags are also pushed to
-#   docker.io. When unset, the workflow still builds and pushes **GHCR only** (no extra secrets).
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   DOCKERHUB_USERNAME
+#   DOCKERHUB_TOKEN      (Docker Hub access token / PAT with read & write)
+#
+# If either Docker Hub secret is unset, the build-push job is skipped (configure both to publish
+# dev images to Docker Hub and GHCR).
 #
 # GHCR: GitHub forbids *naming* a repo secret GITHUB_* (reserved prefix). Use GH_TOKEN
 # for a PAT with write:packages (classic) or "Contents: read" + "Packages: write"
@@ -63,10 +66,12 @@ concurrency:
 jobs:
   build-push:
     if: |
-      (github.event_name == 'pull_request' &&
+      secrets.DOCKERHUB_USERNAME != '' &&
+      secrets.DOCKERHUB_TOKEN != '' &&
+      ((github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false) ||
-      (github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch'))
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR head SHA
@@ -114,7 +119,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -132,7 +136,6 @@ jobs:
         id: meta
         env:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
-          PUSH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         run: |
           set -euo pipefail
           SHORT=$(echo "$HEAD_SHA" | cut -c1-7)
@@ -148,15 +151,9 @@ jobs:
           DOCKERHUB_IMG="docker.io/${REPO_LC}"
           GHCR_IMG="ghcr.io/${REPO_LC}"
 
-          if [ "${PUSH_DOCKERHUB}" = "true" ]; then
-            TAGS="${DOCKERHUB_IMG}:${DEV_TAG}"$'\n'"${GHCR_IMG}:${DEV_TAG}"
-            TAGS+=$'\n'"${DOCKERHUB_IMG}:dev"
-            TAGS+=$'\n'"${GHCR_IMG}:dev"
-          else
-            TAGS="${GHCR_IMG}:${DEV_TAG}"
-            TAGS+=$'\n'"${GHCR_IMG}:dev"
-            echo '::notice::Docker Hub credentials not set — publishing dev image to GHCR only. Add DOCKERHUB_USERNAME and DOCKERHUB_TOKEN to also push docker.io tags.'
-          fi
+          TAGS="${DOCKERHUB_IMG}:${DEV_TAG}"$'\n'"${GHCR_IMG}:${DEV_TAG}"
+          TAGS+=$'\n'"${DOCKERHUB_IMG}:dev"
+          TAGS+=$'\n'"${GHCR_IMG}:dev"
 
           REPO_NAME=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
           LINK_DH="https://hub.docker.com/r/${REPO_LC}/tags?name=${DEV_TAG}"
@@ -164,7 +161,6 @@ jobs:
 
           echo "dev_tag=${DEV_TAG}" >> "$GITHUB_OUTPUT"
           echo "repo_lc=${REPO_LC}" >> "$GITHUB_OUTPUT"
-          echo "push_dockerhub=${PUSH_DOCKERHUB}" >> "$GITHUB_OUTPUT"
           echo "link_dockerhub=${LINK_DH}" >> "$GITHUB_OUTPUT"
           echo "link_ghcr=${LINK_GHCR}" >> "$GITHUB_OUTPUT"
           {
@@ -188,7 +184,6 @@ jobs:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
           DEV_TAG: ${{ steps.meta.outputs.dev_tag }}
           REPO_LC: ${{ steps.meta.outputs.repo_lc }}
-          PUSH_DOCKERHUB: ${{ steps.meta.outputs.push_dockerhub }}
           LINK_DH: ${{ steps.meta.outputs.link_dockerhub }}
           LINK_GHCR: ${{ steps.meta.outputs.link_ghcr }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -203,32 +198,23 @@ jobs:
             const sha = process.env.HEAD_SHA;
             const devTag = process.env.DEV_TAG;
             const repoLc = process.env.REPO_LC;
-            const pushDh = process.env.PUSH_DOCKERHUB === 'true';
             const linkDh = process.env.LINK_DH;
             const linkGhcr = process.env.LINK_GHCR;
             const runUrl = process.env.RUN_URL;
             const commitUrl = process.env.COMMIT_URL;
             const { owner, repo } = context.repo;
             const short = sha.slice(0, 7);
-            const table = [
-              '| Registry | Pull |',
-              '|----------|------|',
-            ];
-            if (pushDh) {
-              table.push(`| **Docker Hub** | [\`docker.io/${repoLc}:${devTag}\`](${linkDh}) |`);
-            }
-            table.push(`| **GHCR** | [\`ghcr.io/${repoLc}:${devTag}\`](${linkGhcr}) |`);
-            const rolling = pushDh
-              ? `**Unique tag:** \`${devTag}\` — **rolling \`dev\`** (same digest as this build): \`docker.io/${repoLc}:dev\` and \`ghcr.io/${repoLc}:dev\`.`
-              : `**Unique tag:** \`${devTag}\` — **rolling \`dev\` on GHCR:** \`ghcr.io/${repoLc}:dev\` (add \`DOCKERHUB_USERNAME\` + \`DOCKERHUB_TOKEN\` to also publish \`docker.io\`).`;
             const body = [
               '### Dev Docker image',
               '',
               `**Multi-arch** (\`linux/amd64\`, \`linux/arm64\`) for commit [\`${short}\`](${commitUrl})`,
               '',
-              ...table,
+              '| Registry | Pull |',
+              '|----------|------|',
+              `| **Docker Hub** | [\`docker.io/${repoLc}:${devTag}\`](${linkDh}) |`,
+              `| **GHCR** | [\`ghcr.io/${repoLc}:${devTag}\`](${linkGhcr}) |`,
               '',
-              rolling,
+              `**Unique tag:** \`${devTag}\` — **rolling \`dev\`** (same digest as this build): \`docker.io/${repoLc}:dev\` and \`ghcr.io/${repoLc}:dev\`.`,
               '',
               `[Workflow run](${runUrl})`,
             ].join('\n');

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,6 +44,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ludeeus/action-shellcheck@2.0.0
 
+  exec-env-issue-88:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Issue #88 — PID 1 + *_FILE secrets (no VPN)
+        run: make test-exec-env
+
   pr-check-against-3-38:
     runs-on: ubuntu-24.04
     steps:

--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -141,13 +141,13 @@ apikey = "secret-apikey-for-gluetrans"
 
 ## Environment Variables
 
-**Mandatory:**
+**Mandatory:** (credentials: use `*_FILE` paths instead of inline values to avoid secret values in `docker exec … env`; see [issue #88](https://github.com/miklosbagi/gluetrans/issues/88))
 - `GLUETUN_CONTROL_ENDPOINT`: Control Server URL, e.g. `http://gluetun:8000`
-- `GLUETUN_CONTROL_API_KEY`: API key for control server (required for v3.40.0+)
+- `GLUETUN_CONTROL_API_KEY` **or** `GLUETUN_CONTROL_API_KEY_FILE`: API key (required for v3.40.0+)
 - `GLUETUN_HEALTH_ENDPOINT`: Health check URL, e.g. `http://gluetun:9999`
 - `TRANSMISSION_ENDPOINT`: Transmission RPC URL, e.g. `http://transmission:9091/transmission/rpc`
-- `TRANSMISSION_USER`: Transmission RPC username
-- `TRANSMISSION_PASS`: Transmission RPC password
+- `TRANSMISSION_USER` **or** `TRANSMISSION_USER_FILE`: Transmission RPC username
+- `TRANSMISSION_PASS` **or** `TRANSMISSION_PASS_FILE`: Transmission RPC password
 
 **Optional:**
 - `PEERPORT_CHECK_INTERVAL`: Validation interval in seconds (default: 15)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 # Use Alpine Linux as the base image
 FROM alpine:3.23.3
 
-# required env vars
-ENV GLUETUN_ENDPOINT=$GLUETUN_ENDPOINT
-ENV TRANSMISSION_ENDPOINT=$TRANSMISSION_ENDPOINT
-ENV TRANSMISSION_USER=$TRANSMISSION_USER
-ENV TRANSMISSION_PASS=$TRANSMISSION_PASS
-ENV PEERPORT_CHECK_INTERVAL=$PEERPORT_CHECK_INTERVAL
+# Runtime configuration is via environment variables only (do not bake ENV placeholders
+# here — empty keys from build-time $VAR expansion show up in `docker exec … env`; see #88).
 
 # install packages
 # hadolint ignore=DL3018
@@ -18,5 +14,7 @@ COPY entrypoint.sh /entrypoint.sh
 # Make the script executable
 RUN chmod +x /entrypoint.sh
 
-# Run the script when the container starts
-CMD ["sh", "-c", "echo 'GlueTrans starting...'; sleep 5; /entrypoint.sh"]
+# Bash as PID 1 runs entrypoint in-process so unset removes secrets from init environ.
+# See issue #88; `docker exec … env` may still replay create-time `-e` secrets unless
+# you use *_FILE env vars (no secret values in container config).
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ lint:
 	@shellcheck entrypoint.sh && echo "✅ ./entrypoint.sh linting passed." || (echo "❌ ./entrypoint.sh linting failed." && exit 1)
 	@shellcheck test/run-smoke.sh && echo "✅ test/run-smoke.sh linting passed." || (echo "❌ test/run-smoke.sh linting failed." && exit 1)
 	@shellcheck test/run-debug-test.sh && echo "✅ test/run-debug-test.sh linting passed." || (echo "❌ test/run-debug-test.sh linting failed." && exit 1)
+	@shellcheck test/run-exec-env-test.sh && echo "✅ test/run-exec-env-test.sh linting passed." || (echo "❌ test/run-exec-env-test.sh linting failed." && exit 1)
 	@hadolint Dockerfile && echo "✅ Dockerfile linting passed." || (echo "❌ Dockerfile linting failed." && exit 1)
 
 release-dev: test
@@ -49,7 +50,11 @@ else
 	@echo "❌ Please provide a version number using 'make release-version VERSION=vX.Y'"
 endif
 
-test: lint pr-test test-debug-mode
+test: lint test-exec-env pr-test test-debug-mode
+
+# Issue #88: PID 1 unset + *_FILE secrets (no VPN; uses local docker/podman)
+test-exec-env:
+	@test/run-exec-env-test.sh && echo "✅ Exec-env tests pass." || (echo "❌ Exec-env tests failed." && exit 1)
 
 pr-test: test-env-start test-run-all test-env-stop
 
@@ -104,4 +109,4 @@ test-run-debug:
 	  docker compose -f test/docker-compose-build-debug.yaml logs gluetrans | tail -n 100; \
 	  exit 1)
 
-.PHONY: all build lint release-dev release-latest release-version test test-env-start test-env-stop test-run-all test-debug-mode test-debug-env-start test-debug-env-stop test-run-debug
+.PHONY: all build lint release-dev release-latest release-version test test-exec-env test-env-start test-env-stop test-run-all test-debug-mode test-debug-env-start test-debug-env-stop test-run-debug

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Supported gluetun versions: v3.35 through v3.41.0 (and minor versions), see test
 
 It keeps trying until you have a valid peer port.
 ## Environment variables
-Mandatory:
+Mandatory (each credential: **either** the value variable **or** the corresponding `*_FILE` path — not both):
 - `GLUETUN_CONTROL_ENDPOINT`: Full Control Server URL with port, e.g.: `http://gluetun:8000`.
-- `GLUETUN_CONTROL_API_KEY`: API key for the control server. This is requried from gluetun versions newer than v3.40.0.
+- `GLUETUN_CONTROL_API_KEY` **or** `GLUETUN_CONTROL_API_KEY_FILE`: API key for the control server (required for gluetun newer than v3.40.0). Use the `*_FILE` form with a [Docker secret](https://docs.docker.com/engine/swarm/secrets/) or bind-mounted file so secret **values** are not in container config (see [issue #88](https://github.com/miklosbagi/gluetrans/issues/88); `podman exec … env` can still replay inline `-e` secrets).
 - `GLUETUN_HEALTH_ENDPOINT`: Full Health URL with port, `http://gluetun:9999` by default.
 - `TRANSMISSION_ENDPOINT` : Full Transmission RPC URL with port, service path, e.g.: `http://transmission:9091/transmission/rpc`.
-- `TRANSMISSION_USER`: Username for transmission RPC auth.
-- `TRANSMISSION_PASS`: Password for transmission RPC auth.
+- `TRANSMISSION_USER` **or** `TRANSMISSION_USER_FILE`: Transmission RPC username (or file containing it).
+- `TRANSMISSION_PASS` **or** `TRANSMISSION_PASS_FILE`: Transmission RPC password (or file containing it).
 
 Optional:
 - `PEERPORT_CHECK_INTERVAL`: how often peer port should be validated. Default: 15, in seconds.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo 'GlueTrans starting...'
+sleep 5
+
 # GlueTrans: A Gluetun + Transmission + VPN peer port updater
 # Please take a look at https://github.com/miklosbagi/gluetrans for more information.
 # Further recommended reading:
@@ -12,14 +15,22 @@
 # Mandatory env vars, please set these:
 # GLUETUN_CONTROL_ENDPOINT
 # GLUETUN_HEALTH_ENDPOINT
-# GLUETUN_CONTROL_API_KEY
 # TRANSMISSION_ENDPOINT
-# TRANSMISSION_USER
-# TRANSMISSION_PASS
+# Plus either inline or *_FILE (see below):
+#   GLUETUN_CONTROL_API_KEY  OR  GLUETUN_CONTROL_API_KEY_FILE
+#   TRANSMISSION_USER        OR  TRANSMISSION_USER_FILE
+#   TRANSMISSION_PASS        OR  TRANSMISSION_PASS_FILE
 #
 # Optional security/debugging env vars:
 # DEBUG: Set to 1 to keep sensitive env vars visible for debugging (default: 0)
 # SANITIZE_LOGS: Set to 1 to omit sensitive information from logs (default: 0)
+#
+# Secrets and `docker exec … env` (issue #88): many runtimes inject **create-time**
+# container env into `exec` sessions, so values passed as `-e GLUETUN_CONTROL_API_KEY=…`
+# can still appear there even after `unset` in PID 1. To avoid **secret values** in
+# `exec env`, pass only the path variables below (no inline secrets in compose):
+#   GLUETUN_CONTROL_API_KEY_FILE, TRANSMISSION_USER_FILE, TRANSMISSION_PASS_FILE
+#
 # Optional timeouts (issue #89): avoid long blocks when Gluetun/Transmission are slow
 # CURL_API_TIMEOUT: max seconds for curl to Gluetun API and country endpoints (default: 10)
 # RPC_TIMEOUT: max seconds for transmission-remote RPC calls (default: 15)
@@ -48,10 +59,7 @@ transmission_port_fail_count=0
 
 required_vars=(
     GLUETUN_CONTROL_ENDPOINT
-    GLUETUN_CONTROL_API_KEY
     TRANSMISSION_ENDPOINT
-    TRANSMISSION_USER
-    TRANSMISSION_PASS
     GLUETUN_HEALTH_ENDPOINT
 )
 
@@ -167,7 +175,7 @@ pick_new_gluetun_server() {
     wait_for_gluetun
 }
 
-# exit of any env var is unset
+# exit if any required (non-secret) env var is unset
 for var in "${required_vars[@]}"; do
     if [[ -z "${!var}" ]]; then
         echo "$var is not set. please set the environment variable." >&2
@@ -175,27 +183,80 @@ for var in "${required_vars[@]}"; do
     fi
 done
 
-# Store sensitive credentials in memory and remove from environment
-# This prevents them from being visible via 'docker exec <container> env'
-_gluetun_api_key="$GLUETUN_CONTROL_API_KEY"
-_transmission_user="$TRANSMISSION_USER"
-_transmission_pass="$TRANSMISSION_PASS"
-
-# Unset sensitive environment variables (unless DEBUG mode is enabled)
-if [[ "$DEBUG" != "1" ]]; then
+# --- Credentials: load from *_FILE (recommended for issue #88) or inline env ---
+if [[ -n "${GLUETUN_CONTROL_API_KEY_FILE:-}" && -n "${GLUETUN_CONTROL_API_KEY:-}" ]]; then
+    echo "Set only one of GLUETUN_CONTROL_API_KEY or GLUETUN_CONTROL_API_KEY_FILE" >&2
+    exit 1
+fi
+if [[ -n "${GLUETUN_CONTROL_API_KEY_FILE:-}" ]]; then
+    if [[ ! -f "${GLUETUN_CONTROL_API_KEY_FILE}" || ! -r "${GLUETUN_CONTROL_API_KEY_FILE}" ]]; then
+        echo "GLUETUN_CONTROL_API_KEY_FILE is not a readable file" >&2
+        exit 1
+    fi
+    _gluetun_api_key=$(tr -d '\r\n' < "${GLUETUN_CONTROL_API_KEY_FILE}")
+    unset GLUETUN_CONTROL_API_KEY_FILE
+    unset GLUETUN_CONTROL_API_KEY 2>/dev/null || true
+elif [[ -n "${GLUETUN_CONTROL_API_KEY:-}" ]]; then
+    _gluetun_api_key="$GLUETUN_CONTROL_API_KEY"
     unset GLUETUN_CONTROL_API_KEY
+else
+    echo "GLUETUN_CONTROL_API_KEY or GLUETUN_CONTROL_API_KEY_FILE must be set" >&2
+    exit 1
+fi
+
+if [[ -n "${TRANSMISSION_USER_FILE:-}" && -n "${TRANSMISSION_USER:-}" ]]; then
+    echo "Set only one of TRANSMISSION_USER or TRANSMISSION_USER_FILE" >&2
+    exit 1
+fi
+if [[ -n "${TRANSMISSION_USER_FILE:-}" ]]; then
+    if [[ ! -f "${TRANSMISSION_USER_FILE}" || ! -r "${TRANSMISSION_USER_FILE}" ]]; then
+        echo "TRANSMISSION_USER_FILE is not a readable file" >&2
+        exit 1
+    fi
+    _transmission_user=$(tr -d '\r\n' < "${TRANSMISSION_USER_FILE}")
+    unset TRANSMISSION_USER_FILE
+    unset TRANSMISSION_USER 2>/dev/null || true
+elif [[ -n "${TRANSMISSION_USER:-}" ]]; then
+    _transmission_user="$TRANSMISSION_USER"
     unset TRANSMISSION_USER
+else
+    echo "TRANSMISSION_USER or TRANSMISSION_USER_FILE must be set" >&2
+    exit 1
+fi
+
+if [[ -n "${TRANSMISSION_PASS_FILE:-}" && -n "${TRANSMISSION_PASS:-}" ]]; then
+    echo "Set only one of TRANSMISSION_PASS or TRANSMISSION_PASS_FILE" >&2
+    exit 1
+fi
+if [[ -n "${TRANSMISSION_PASS_FILE:-}" ]]; then
+    if [[ ! -f "${TRANSMISSION_PASS_FILE}" || ! -r "${TRANSMISSION_PASS_FILE}" ]]; then
+        echo "TRANSMISSION_PASS_FILE is not a readable file" >&2
+        exit 1
+    fi
+    _transmission_pass=$(tr -d '\r\n' < "${TRANSMISSION_PASS_FILE}")
+    unset TRANSMISSION_PASS_FILE
+    unset TRANSMISSION_PASS 2>/dev/null || true
+elif [[ -n "${TRANSMISSION_PASS:-}" ]]; then
+    _transmission_pass="$TRANSMISSION_PASS"
     unset TRANSMISSION_PASS
+else
+    echo "TRANSMISSION_PASS or TRANSMISSION_PASS_FILE must be set" >&2
+    exit 1
+fi
+
+# Unset / re-export for DEBUG; keep secrets in _vars unless DEBUG=1
+if [[ "$DEBUG" == "1" ]]; then
+    export GLUETUN_CONTROL_API_KEY="$_gluetun_api_key"
+    export TRANSMISSION_USER="$_transmission_user"
+    export TRANSMISSION_PASS="$_transmission_pass"
+    log "debug: DEBUG=1, sensitive environment variables re-exported for visibility"
+else
     log "security: sensitive environment variables removed from environment (stored in memory only)"
-    
-    # Verify the unset worked (for the main script process)
-    if [[ -z "$GLUETUN_CONTROL_API_KEY" ]] && [[ -z "$TRANSMISSION_USER" ]] && [[ -z "$TRANSMISSION_PASS" ]]; then
+    if [[ -z "${GLUETUN_CONTROL_API_KEY:-}" && -z "${TRANSMISSION_USER:-}" && -z "${TRANSMISSION_PASS:-}" ]]; then
         log "security: verified - sensitive vars are not accessible in main process environment"
     else
         log "warning: unset may not have worked as expected"
     fi
-else
-    log "debug: DEBUG=1, keeping sensitive environment variables visible"
 fi
 
 # wait for gluetun to wake up

--- a/test/README.md
+++ b/test/README.md
@@ -22,6 +22,9 @@ Please take a look at the [docker-compose](./docker-compose-build.yaml) file.
 - Shellcheck is used for shell scripts: `shellcheck entrypoint.sh`
 - Hadolint is used for dockerfile: `hadolint Dockerfile`
 
+## Issue #88 — exec environment (`make test-exec-env`)
+No VPN. Builds the image and checks (1) the security unset path for inline `-e` secrets, and (2) that with **only** `GLUETUN_CONTROL_API_KEY_FILE` / `TRANSMISSION_USER_FILE` / `TRANSMISSION_PASS_FILE`, `docker exec … env` does not contain the secret values.
+
 ## Smoke pack
 `make test-run-smoke` (depends on test infrastructure).
 

--- a/test/run-exec-env-test.sh
+++ b/test/run-exec-env-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Issue #88: verify (1) PID 1 environ has no inline secret names after unset, and
+# (2) with *_FILE only (no inline secrets in container config), `exec … env` has no
+# secret *values* for the three credentials.
+# No VPN. Use DOCKER_CMD=podman for Podman.
+set -euo pipefail
+
+DOCKER_CMD="${DOCKER_CMD:-docker}"
+IMAGE_NAME="gluetrans-exec-env-test"
+CONTAINER_NAME="gluetrans-exec-env-test"
+
+export GLUETUN_CONTROL_ENDPOINT="http://localhost:8000"
+export GLUETUN_HEALTH_ENDPOINT="http://localhost:9999"
+export TRANSMISSION_ENDPOINT="http://localhost:9091/transmission/rpc"
+
+cleanup() {
+    $DOCKER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Building image (DOCKER_CMD=$DOCKER_CMD)..."
+if [ "$DOCKER_CMD" = "podman" ]; then
+    $DOCKER_CMD build -t "$IMAGE_NAME" .
+else
+    # --load: required when the default builder is docker-container (image must exist in local daemon)
+    docker buildx build --load -t "$IMAGE_NAME" .
+fi
+
+# --- Test A: inline -e secrets (legacy compose); entrypoint must log successful unset ---
+echo "=== Test A: inline secrets — security log path ==="
+$DOCKER_CMD rm -f "$CONTAINER_NAME" 2>/dev/null || true
+$DOCKER_CMD run -d --name "$CONTAINER_NAME" \
+    -e GLUETUN_CONTROL_ENDPOINT \
+    -e GLUETUN_HEALTH_ENDPOINT \
+    -e TRANSMISSION_ENDPOINT \
+    -e GLUETUN_CONTROL_API_KEY="secret-api-key-must-not-appear-in-pid1" \
+    -e TRANSMISSION_USER="testuser" \
+    -e TRANSMISSION_PASS="testpass" \
+    "$IMAGE_NAME"
+
+for _i in $(seq 1 20); do
+    if $DOCKER_CMD logs "$CONTAINER_NAME" 2>&1 | grep -q "sensitive environment variables removed from environment" \
+        && $DOCKER_CMD logs "$CONTAINER_NAME" 2>&1 | grep -q "verified - sensitive vars are not accessible in main process environment"; then
+        break
+    fi
+    if [ "$_i" -eq 20 ]; then
+        echo "  😵 timeout waiting for security log lines"
+        $DOCKER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -30
+        exit 1
+    fi
+    sleep 1
+done
+echo "  👍🏻 Security unset path ran (see issue #88: many runtimes still show inline -e values in 'exec env'; use *_FILE to hide values)"
+
+# --- Test B: *_FILE only; exec env must not expose secret values ---
+echo "=== Test B: *_FILE only — no secret values in exec env ==="
+cleanup
+SECRET_DIR=$(mktemp -d)
+printf '%s' 'file-based-api-key' >"$SECRET_DIR/api"
+printf '%s' 'file-based-user' >"$SECRET_DIR/tuser"
+printf '%s' 'file-based-pass' >"$SECRET_DIR/tpass"
+chmod 600 "$SECRET_DIR"/*
+
+$DOCKER_CMD run -d --name "$CONTAINER_NAME" \
+    -v "$SECRET_DIR/api:/run/gtsecrets/api:ro" \
+    -v "$SECRET_DIR/tuser:/run/gtsecrets/tuser:ro" \
+    -v "$SECRET_DIR/tpass:/run/gtsecrets/tpass:ro" \
+    -e GLUETUN_CONTROL_ENDPOINT \
+    -e GLUETUN_HEALTH_ENDPOINT \
+    -e TRANSMISSION_ENDPOINT \
+    -e GLUETUN_CONTROL_API_KEY_FILE=/run/gtsecrets/api \
+    -e TRANSMISSION_USER_FILE=/run/gtsecrets/tuser \
+    -e TRANSMISSION_PASS_FILE=/run/gtsecrets/tpass \
+    "$IMAGE_NAME"
+
+for _i in $(seq 1 20); do
+    if $DOCKER_CMD logs "$CONTAINER_NAME" 2>&1 | grep -q "sensitive environment variables removed from environment"; then
+        break
+    fi
+    if [ "$_i" -eq 20 ]; then
+        echo "  😵 timeout waiting for security log (file mode)"
+        $DOCKER_CMD logs "$CONTAINER_NAME" 2>&1 | tail -30
+        exit 1
+    fi
+    sleep 1
+done
+
+exec_env=$($DOCKER_CMD exec "$CONTAINER_NAME" env 2>&1)
+for needle in file-based-api-key file-based-user file-based-pass; do
+    if echo "$exec_env" | grep -q "$needle"; then
+        echo "  😵 exec env still contains secret value fragment: $needle"
+        exit 1
+    fi
+done
+# Inline names must not be set to values (compose did not pass them)
+for var in GLUETUN_CONTROL_API_KEY TRANSMISSION_USER TRANSMISSION_PASS; do
+    if echo "$exec_env" | grep -qE "^${var}="; then
+        echo "  😵 exec env has ${var}= (unexpected in file-only mode)"
+        exit 1
+    fi
+done
+echo "  👍🏻 exec env has no credential names or file-based secret values"
+
+cleanup
+rm -rf "$SECRET_DIR"
+echo "✅ Exec-env tests passed."


### PR DESCRIPTION
## Summary
Addresses [issue #88](https://github.com/miklosbagi/gluetrans/issues/88): sensitive values still visible via `docker exec` / `podman exec … env` after PR #90.

## Root cause
- **PID 1**: If the main process is `sh -c` wrapping the script, `unset` in the child does not apply to init as seen by some tooling.
- **Exec env**: Many runtimes inject **create-time** container config into `exec` sessions, so **inline** `-e SECRET=value` can still appear even after the entrypoint unsets them in PID 1.

## What this PR does
- **Dockerfile**: `ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]` so bash is PID 1; removed misleading `ENV VAR=$VAR` lines that left empty keys in every image.
- **entrypoint**: `GLUETUN_CONTROL_API_KEY_FILE`, `TRANSMISSION_USER_FILE`, `TRANSMISSION_PASS_FILE` — read file contents, error if both file and inline set; `unset` paths and inline names after copying to internal vars. `DEBUG=1` re-exports for debugging.
- **Docs** (`README.md`, `DOCKERHUB_README.md`): document `*_FILE` and link #88.
- **CI**: `make test-exec-env` — Test A: inline `-e` → security log lines; Test B: file-only secrets → `docker exec … env` must not contain secret values or credential keys.
- **Makefile / test README**: wire `test-exec-env` into lint and `make test`.

## User guidance
To avoid **secret values** in `exec env`, use Docker/Compose **secrets** or bind mounts with `*_FILE` and **do not** pass inline secret `-e` values.

Rebases on latest `main` (includes #89 timeout envs); merged comment block documents both #88 and #89.

Closes #88 when merged (or we can keep open until reporter confirms). Supersedes / complements #90.