### PR TITLE
docs(test): Gluetun API key via env (HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE) (#92)

### DIFF
--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -26,16 +26,15 @@ AMD64 and ARM64 platforms are supported.
 > - **Gluetun v3.41.0+**: Uses new API (`/v1/portforward`, `/v1/vpn/status`)
 > - **Gluetun v3.40.0 and older**: Uses old API (`/v1/openvpn/portforwarded`, `/v1/openvpn/status`)
 >
-> The script automatically tries the new endpoint first and falls back to the old one if needed. However, your `config.toml` must match your Gluetun version (see below).
+> The script automatically tries the new endpoint first and falls back to the old one if needed. If you use a bind-mounted Gluetun `config.toml` (v3.38–v3.40.0 or per-route roles), its routes must match your Gluetun version (see below).
 
 > **Warning:** Starting from gluetun 3.40.0+ versions, control server requires authentication.  
 > Gluetrans, from version 0.3.5 and above provides support for this change, but an API key must be provided.  
 > 
-> Quick setup:
-> 1. Set `GLUETUN_CONTROL_API_KEY` in your environment variables
-> 2. Create a role in gluetun's `config.toml` with the same API key
-> 3. Map `config.toml` to gluetun container
-> 4. Set the same API key in gluetrans' environment variables
+> Quick setup (see [Gluetun control server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#configuration)):
+> 1. **Gluetun v3.41.0+:** set `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` on gluetun (JSON with API key; [issue #92](https://github.com/miklosbagi/gluetrans/issues/92)).
+> 2. Set `GLUETUN_CONTROL_API_KEY` on gluetrans to the **same** key.
+> 3. **Gluetun v3.38–v3.40.0:** bind-mount `config.toml` instead (env-based default role is not available before v3.41.0).
 
 ## Minimal Example
 
@@ -54,7 +53,7 @@ miklosbagi/gluetrans:latest
 
 ### PIA/ProtonVPN with Gluetun + Transmission
 
-**CI smoke tests** use **Private Internet Access** (see `test/docker-compose-build.yaml`). Full stack example (PIA):
+**CI smoke tests** use **Private Internet Access** (see `test/docker-compose-build.yaml` for v3.41.0+ or `test/docker-compose-build-legacy-gluetun.yaml` for v3.38–v3.40.0). Full stack example (PIA):
 
 ```yaml
 services:
@@ -72,9 +71,9 @@ services:
       SERVER_REGIONS: "Switzerland,DE Berlin,FI Helsinki,France"
       VPN_PORT_FORWARDING: on
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
+      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
     volumes:
       - ./data/gluetun:/gluetun
-      - ./gluetun-config/config.toml:/gluetun/auth/config.toml  # Required for v3.40.0+
     devices:
       - /dev/net/tun:/dev/net/tun
     restart: unless-stopped
@@ -97,7 +96,7 @@ services:
     environment:
       GLUETUN_CONTROL_ENDPOINT: http://localhost:8000
       GLUETUN_HEALTH_ENDPOINT: http://localhost:9999
-      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans"
+      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans"  # same key as Gluetun HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE
       TRANSMISSION_ENDPOINT: http://localhost:9091/transmission/rpc
       TRANSMISSION_USER: My Transmission Username
       TRANSMISSION_PASS: My Transmission Password
@@ -111,13 +110,15 @@ services:
 
 For **ProtonVPN**, use `VPN_SERVICE_PROVIDER: "protonvpn"`, **`SERVER_COUNTRIES`** (not `SERVER_REGIONS`), and `VPN_PORT_FORWARDING_PROVIDER: "protonvpn"`. See [Gluetun ProtonVPN setup](https://github.com/qdm12/gluetun-wiki/blob/main/setup/providers/protonvpn.md) and the compose snippet in the [GitHub README](https://github.com/miklosbagi/gluetrans/blob/main/README.md).
 
-## Gluetun config.toml
+## Gluetun `config.toml` (optional)
 
-For control server authentication, `config.toml` is required to allow gluetrans to send authenticated requests to gluetun.
+**Gluetun v3.41.0+:** prefer `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` on gluetun (see compose example above). A bind-mounted `config.toml` is optional if you need [per-route roles](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#configuration).
 
-**Choose the config that matches YOUR Gluetun version:**
+**Gluetun v3.38–v3.40.0:** use `config.toml` at `/gluetun/auth/config.toml`; `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` is not available before v3.41.0.
 
-### For Gluetun v3.41.0 and newer (new API endpoints)
+When you use a file, pick the snippet that matches your Gluetun version’s routes:
+
+### Gluetun v3.41.0 and newer (new API endpoints)
 
 ```toml
 [[roles]]
@@ -127,7 +128,7 @@ auth = "apikey"
 apikey = "secret-apikey-for-gluetrans"
 ```
 
-### For Gluetun v3.40.0 and older (old API endpoints)
+### Gluetun v3.40.0 and older (old API endpoints)
 
 ```toml
 [[roles]]
@@ -137,7 +138,7 @@ auth = "apikey"
 apikey = "secret-apikey-for-gluetrans"
 ```
 
-**Why separate configs?** Gluetun validates routes at startup and will reject routes that don't exist in that version. The gluetrans script automatically handles the API differences.
+**Why separate configs?** Gluetun validates listed routes at startup. Gluetrans still picks HTTP paths automatically; the file must list paths that exist on your Gluetun version.
 
 ## Environment Variables
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,21 @@ SHELL := /bin/bash
 DOCKER_REPO := miklosbagi/gluetrans
 GHCR_REPO := ghcr.io/miklosbagi/gluetranspia
 DOCKER_BUILD_CMD := docker buildx build --platform linux/amd64,linux/arm64
-DOCKER_COMPOSE_CMD := docker compose -f test/docker-compose-build.yaml
-
 GLUETUN_VERSION := v3.41.0
+# Gluetun v3.41.0+ supports HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE; older CI matrix tags still use config.toml (issue #92).
+LEGACY_GLUETUN_CONTROL_AUTH := $(shell echo '$(GLUETUN_VERSION)' | grep -qE '^v3\.(38|39|40\.0)$$' && echo legacy || echo modern)
+ifeq ($(LEGACY_GLUETUN_CONTROL_AUTH),legacy)
+export GLUETRANS_COMPOSE_FILE := test/docker-compose-build-legacy-gluetun.yaml
+export GLUETRANS_COMPOSE_DEBUG_FILE := test/docker-compose-build-debug-legacy-gluetun.yaml
+DOCKER_COMPOSE_CMD := docker compose -f $(GLUETRANS_COMPOSE_FILE)
+DOCKER_COMPOSE_DEBUG_CMD := docker compose -f $(GLUETRANS_COMPOSE_DEBUG_FILE)
+else
+export GLUETRANS_COMPOSE_FILE := test/docker-compose-build.yaml
+export GLUETRANS_COMPOSE_DEBUG_FILE := test/docker-compose-build-debug.yaml
+DOCKER_COMPOSE_CMD := docker compose -f $(GLUETRANS_COMPOSE_FILE)
+DOCKER_COMPOSE_DEBUG_CMD := docker compose -f $(GLUETRANS_COMPOSE_DEBUG_FILE)
+endif
+
 TRANSMISSION_VERSION := 4.0.6
 SANITIZE_LOGS := 0
 # Optional: FIX=89 make release-dev → tags dev-89 (Docker Hub + GHCR) for testing multiple dev builds
@@ -56,13 +68,9 @@ pr-test: test-env-start test-run-all test-env-stop
 test-debug-mode: test-debug-env-start test-run-debug test-debug-env-stop
 
 test-env-start: test-env-stop
-	@# Select appropriate config.toml based on Gluetun version
-	@if echo "$(GLUETUN_VERSION)" | grep -qE "^v3\.(38|39|40\.0)$$|^latest$$"; then \
-		echo "Using old API config for Gluetun $(GLUETUN_VERSION)"; \
+	@if [ "$(LEGACY_GLUETUN_CONTROL_AUTH)" = legacy ]; then \
+		echo "Using bind-mounted config.toml for Gluetun $(GLUETUN_VERSION) (pre–v3.41.0 control auth)"; \
 		cp test/gluetun-config/config-old.toml test/gluetun-config/config.toml; \
-	else \
-		echo "Using new API config for Gluetun $(GLUETUN_VERSION)"; \
-		cp test/gluetun-config/config-new.toml test/gluetun-config/config.toml; \
 	fi
 	SANITIZE_LOGS=0 && $(DOCKER_COMPOSE_CMD) up --no-deps --build --force-recreate --remove-orphans --detach
 
@@ -70,18 +78,14 @@ test-env-stop:
 	$(DOCKER_COMPOSE_CMD) down --remove-orphans --volumes
 
 test-debug-env-start: test-debug-env-stop
-	@# Select appropriate config.toml based on Gluetun version
-	@if echo "$(GLUETUN_VERSION)" | grep -qE "^v3\.(38|39|40\.0)$$|^latest$$"; then \
-		echo "Using old API config for Gluetun $(GLUETUN_VERSION)"; \
+	@if [ "$(LEGACY_GLUETUN_CONTROL_AUTH)" = legacy ]; then \
+		echo "Using bind-mounted config.toml for Gluetun $(GLUETUN_VERSION) (pre–v3.41.0 control auth)"; \
 		cp test/gluetun-config/config-old.toml test/gluetun-config/config.toml; \
-	else \
-		echo "Using new API config for Gluetun $(GLUETUN_VERSION)"; \
-		cp test/gluetun-config/config-new.toml test/gluetun-config/config.toml; \
 	fi
-	SANITIZE_LOGS=0 && docker compose -f test/docker-compose-build-debug.yaml up --no-deps --build --force-recreate --remove-orphans --detach
+	SANITIZE_LOGS=0 && $(DOCKER_COMPOSE_DEBUG_CMD) up --no-deps --build --force-recreate --remove-orphans --detach
 
 test-debug-env-stop:
-	docker compose -f test/docker-compose-build-debug.yaml down --remove-orphans --volumes
+	$(DOCKER_COMPOSE_DEBUG_CMD) down --remove-orphans --volumes
 
 test-run-sonar:
 	sonar-scanner \
@@ -99,9 +103,9 @@ test-run-all:
 
 test-run-debug:
 	@test/run-debug-test.sh && echo "✅ DEBUG mode tests pass." || (echo "❌ DEBUG mode tests failed." && \
-	  docker compose -f test/docker-compose-build-debug.yaml logs gluetun | tail -n 100; \
-	  docker compose -f test/docker-compose-build-debug.yaml logs transmission | tail -n 100; \
-	  docker compose -f test/docker-compose-build-debug.yaml logs gluetrans | tail -n 100; \
+	  $(DOCKER_COMPOSE_DEBUG_CMD) logs gluetun | tail -n 100; \
+	  $(DOCKER_COMPOSE_DEBUG_CMD) logs transmission | tail -n 100; \
+	  $(DOCKER_COMPOSE_DEBUG_CMD) logs gluetrans | tail -n 100; \
 	  exit 1)
 
 .PHONY: all build lint release-dev release-latest release-version test test-env-start test-env-stop test-run-all test-debug-mode test-debug-env-start test-debug-env-stop test-run-debug

--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ Supported gluetun versions: v3.35 through v3.41.0 (and minor versions), see test
 > - **v3.41.0+**: Uses new API (`/v1/portforward`, `/v1/vpn/status`)
 > - **v3.40.0 and older**: Uses old API (`/v1/openvpn/portforwarded`, `/v1/openvpn/status`)
 >
-> The script automatically tries the new endpoint first and falls back to the old one if needed. However, your `config.toml` must match your Gluetun version (see below).
+> The script automatically tries the new endpoint first and falls back to the old one if needed. If you use a **bind-mounted** Gluetun `config.toml` for control auth (Gluetun v3.38–v3.40.0 or fine-grained routes), that file’s routes must match your Gluetun version (see [Gluetun `config.toml`](#gluetun-configtoml-optional)).
 
 > [!WARNING]
 > Breaking change ahead: starting from gluetun 3.40.0+ versions, control server requires authentication. You can read more about this in [gluetun control server documentation](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication).<br>
-> Gluetrans, from version 0.3.5 and above provides support for this change, but an API key must be provided. Please [consult compose the examples](#docker-compose-examples) and [config.toml example](#gluetun-configtoml) below.<br><br>
-> In short:
-> 1. Set `GLUETUN_CONTROL_API_KEY` in your environment variables.
-> 1. Create a role in gluetun's `config.toml` with the same API key.
-> 1. Map `config.toml` to gluetun container.
-> 1. Set the same API key in gluetrans' environment variables.
+> Gluetrans, from version 0.3.5 and above provides support for this change, but an API key must be provided. The usual setup is:
+> 1. **Gluetun v3.41.0+:** set `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` on gluetun (JSON with `"auth":"apikey"` — see [wiki](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#configuration) and [issue #92](https://github.com/miklosbagi/gluetrans/issues/92)); no `config.toml` mount required for the default case.
+> 2. Set `GLUETUN_CONTROL_API_KEY` on gluetrans to the **same** key.
+> 3. **Gluetun v3.38–v3.40.0:** use a bind-mounted `config.toml` instead (that env var exists only from v3.41.0); see [Docker-compose examples](#docker-compose-examples) and [optional `config.toml`](#gluetun-configtoml-optional).
 
 ## What does it do?
 1. Waits for gluetun to report healthy
@@ -122,9 +120,8 @@ services:
       SERVER_REGIONS: "FI Helsinki,France,Norway,SE Stockholm,Serbia"
       VPN_PORT_FORWARDING: on
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
-    # from gluetun v3.40.0+ control server auth, mapping config.toml with api key is required
-    volumes:
-      - ./gluetun-config/config.toml:/gluetun/auth/config.toml
+      # Control server API key (Gluetun v3.41.0+); same key as GLUETUN_CONTROL_API_KEY on gluetrans
+      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
     restart: unless-stopped
     # for ubuntu-latest, you may need:
     devices:
@@ -149,8 +146,8 @@ services:
     environment:
       GLUETUN_CONTROL_ENDPOINT: http://localhost:8000
       GLUETUN_HEALTH_ENDPOINT: http://localhost:9999
-      # from gluetun v3.40.0+ control server auth key must be passed
-      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match the one in config.toml
+      # Same API key as Gluetun HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE
+      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans"
       TRANSMISSION_ENDPOINT: http://localhost:9091/transmission/rpc
       TRANSMISSION_USER: My Transmission Username
       TRANSMISSION_PASS: My Transmission Password
@@ -184,9 +181,7 @@ services:
       SERVER_COUNTRIES: "Romania,Poland,Netherlands,Moldova"
       VPN_PORT_FORWARDING: on
       VPN_PORT_FORWARDING_PROVIDER: "protonvpn"
-    # from gluetun v3.40.0+ control server auth, mapping config.toml with api key is required
-    volumes:
-      - ./gluetun-config/config.toml:/gluetun/auth/config.toml
+      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
     restart: unless-stopped
     # for ubuntu-latest, you may need:
     devices:
@@ -196,15 +191,18 @@ services:
   gluetrans: ....same as with piavpn above...
 ```
 
-Please note that the PIA example above is the reference layout. **CI smoke tests** use **Private Internet Access** with Gluetun; see [`test/docker-compose-build.yaml`](test/docker-compose-build.yaml) and [`test/README.md`](test/README.md) for the exact environment variables.
+Please note that the PIA example above is the reference layout. **CI smoke tests** use **Private Internet Access** with Gluetun; see [`test/docker-compose-build.yaml`](test/docker-compose-build.yaml) (Gluetun v3.41.0+ with `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE`) or [`test/docker-compose-build-legacy-gluetun.yaml`](test/docker-compose-build-legacy-gluetun.yaml) (v3.38–v3.40.0 with `config.toml`) and [`test/README.md`](test/README.md).
 
-### Gluetun config.toml
-For control server authentication, `config.toml` will be required to allow gluetrans to send authenticated requests to gluetun.
+### Gluetun `config.toml` (optional)
 
-**Choose the config that matches YOUR Gluetun version:**
+**Gluetun v3.41.0 and newer:** you can configure control-server API key auth with **`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE`** on the gluetun service (JSON string), as in the [compose examples](#docker-compose-examples) above — no bind-mounted `config.toml` is required unless you want [separate roles per route](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#configuration).
+
+**Gluetun v3.38–v3.40.0:** use a bind-mounted `config.toml` at `/gluetun/auth/config.toml`; the `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` environment variable is not available before v3.41.0.
+
+Use the snippet below that matches your Gluetun version’s HTTP routes (Gluetun validates routes at startup).
 
 <details>
-<summary><b>For Gluetun v3.41.0 and newer</b> (new API endpoints)</summary>
+<summary><b>Gluetun v3.41.0 and newer</b> (new API endpoints)</summary>
 
 ```toml
 [[roles]]
@@ -216,7 +214,7 @@ apikey = "secret-apikey-for-gluetrans"
 </details>
 
 <details>
-<summary><b>For Gluetun v3.40.0 and older</b> (old API endpoints)</summary>
+<summary><b>Gluetun v3.40.0 and older</b> (old API endpoints)</summary>
 
 ```toml
 [[roles]]
@@ -227,7 +225,7 @@ apikey = "secret-apikey-for-gluetrans"
 ```
 </details>
 
-**Why separate configs?** Gluetun validates routes at startup and will reject routes that don't exist in that version. The gluetrans script automatically uses the correct endpoints regardless of your config.
+**Why separate configs?** When you use a file instead of `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE`, Gluetun validates the listed routes at startup. The gluetrans script still picks new vs old HTTP paths automatically; the file must list paths that exist on your Gluetun version.
 
 ## Debug
 `docker logs -f gluetrans` should reveal what's happening.

--- a/test/README.md
+++ b/test/README.md
@@ -9,13 +9,18 @@ Please note that in order to use any of this, the following variables need to be
 These are utilized via [.env](./.env).
 
 ## Test infrastructure
-`make test-env-start` and `make test-env-stop` to start and stop the test environment.
+`make test-env-start` and `make test-env-stop` start and stop the stack defined by `GLUETUN_VERSION`:
+- **Gluetun v3.41.0, `latest`:** [`docker-compose-build.yaml`](./docker-compose-build.yaml) — control API auth via `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` (no `config.toml` mount).
+- **Gluetun v3.38, v3.39, v3.40.0:** [`docker-compose-build-legacy-gluetun.yaml`](./docker-compose-build-legacy-gluetun.yaml) — bind-mounted `test/gluetun-config/config.toml` (see [Makefile](../Makefile) `LEGACY_GLUETUN_CONTROL_AUTH`).
+
+The Makefile exports `GLUETRANS_COMPOSE_FILE` / `GLUETRANS_COMPOSE_DEBUG_FILE` for [`run-smoke.sh`](./run-smoke.sh) and [`run-debug-test.sh`](./run-debug-test.sh).
+
 Components:
 - Gluetun (**Private Internet Access** / OpenVPN in CI)
 - Transmisison
 - GlueTrans
 
-Please take a look at the [docker-compose](./docker-compose-build.yaml) file.
+Please take a look at the compose file selected for your `GLUETUN_VERSION` (paths above).
 
 ## Linters
 `make lint`

--- a/test/docker-compose-build-debug-legacy-gluetun.yaml
+++ b/test/docker-compose-build-debug-legacy-gluetun.yaml
@@ -1,3 +1,4 @@
+# Gluetun v3.38–v3.40.0: control server auth via bind-mounted config.toml only (see Makefile.)
 services:
   gluetun:
     image: qmcgaw/gluetun:${GLUETUN_VERSION}
@@ -13,7 +14,8 @@ services:
       SERVER_REGIONS: ${TEST_VPN_REGIONS}
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
-      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
+    volumes:
+      - ./gluetun-config/config.toml:/gluetun/auth/config.toml
     restart: unless-stopped
     devices:
       - /dev/net/tun:/dev/net/tun
@@ -34,16 +36,16 @@ services:
       context: ../
     environment:
       GLUETUN_CONTROL_ENDPOINT: http://localhost:8000
-      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match Gluetun HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE
+      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match config.toml
       GLUETUN_HEALTH_ENDPOINT: http://localhost:9999
       GLUETUN_PICK_NEW_SERVER_AFTER: 10
       PEERPORT_CHECK_INTERVAL: 30
       TRANSMISSION_ENDPOINT: http://localhost:9091/transmission/rpc
       TRANSMISSION_USER: ${TEST_T_USER}
       TRANSMISSION_PASS: ${TEST_T_PASS}
-      FORCED_COUNTRY_JUMP: 0  # Disable for faster debug test
+      FORCED_COUNTRY_JUMP: 0
       SANITIZE_LOGS: ${SANITIZE_LOGS}
-      DEBUG: 1  # Enable DEBUG mode for this test
+      DEBUG: 1
     network_mode: "service:gluetun"
     depends_on:
       - gluetun

--- a/test/docker-compose-build-legacy-gluetun.yaml
+++ b/test/docker-compose-build-legacy-gluetun.yaml
@@ -1,3 +1,5 @@
+# Gluetun v3.38–v3.40.0: control server auth via bind-mounted config.toml only
+# (HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE is not available before v3.41.0; see Makefile.)
 services:
   gluetun:
     image: qmcgaw/gluetun:${GLUETUN_VERSION}
@@ -13,7 +15,8 @@ services:
       SERVER_REGIONS: ${TEST_VPN_REGIONS}
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
-      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
+    volumes:
+      - ./gluetun-config/config.toml:/gluetun/auth/config.toml
     restart: unless-stopped
     devices:
       - /dev/net/tun:/dev/net/tun
@@ -34,16 +37,15 @@ services:
       context: ../
     environment:
       GLUETUN_CONTROL_ENDPOINT: http://localhost:8000
-      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match Gluetun HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE
+      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match config.toml
       GLUETUN_HEALTH_ENDPOINT: http://localhost:9999
       GLUETUN_PICK_NEW_SERVER_AFTER: 10
       PEERPORT_CHECK_INTERVAL: 30
       TRANSMISSION_ENDPOINT: http://localhost:9091/transmission/rpc
       TRANSMISSION_USER: ${TEST_T_USER}
       TRANSMISSION_PASS: ${TEST_T_PASS}
-      FORCED_COUNTRY_JUMP: 0  # Disable for faster debug test
+      FORCED_COUNTRY_JUMP: 1
       SANITIZE_LOGS: ${SANITIZE_LOGS}
-      DEBUG: 1  # Enable DEBUG mode for this test
     network_mode: "service:gluetun"
     depends_on:
       - gluetun

--- a/test/docker-compose-build.yaml
+++ b/test/docker-compose-build.yaml
@@ -13,8 +13,8 @@ services:
       SERVER_REGIONS: ${TEST_VPN_REGIONS}
       VPN_PORT_FORWARDING: "on"
       VPN_PORT_FORWARDING_PROVIDER: "private internet access"
-    volumes:
-      - ./gluetun-config/config.toml:/gluetun/auth/config.toml
+      # Gluetun v3.41.0+: API key auth without config.toml (see gluetun-wiki control server)
+      HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: '{"auth":"apikey","apikey":"secret-apikey-for-gluetrans"}'
     restart: unless-stopped
     devices:
       - /dev/net/tun:/dev/net/tun
@@ -35,7 +35,7 @@ services:
       context: ../
     environment:
       GLUETUN_CONTROL_ENDPOINT: http://localhost:8000
-      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match the one in config.toml
+      GLUETUN_CONTROL_API_KEY: "secret-apikey-for-gluetrans" # must match Gluetun HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE
       GLUETUN_HEALTH_ENDPOINT: http://localhost:9999
       GLUETUN_PICK_NEW_SERVER_AFTER: 10
       PEERPORT_CHECK_INTERVAL: 30

--- a/test/gluetun-config/config-new.toml
+++ b/test/gluetun-config/config-new.toml
@@ -1,3 +1,4 @@
+# Reference: file-based control auth for Gluetun v3.41+ (CI uses HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE instead; see issue #92).
 [[roles]]
 name = "gluetrans"
 routes = ["GET /v1/portforward", "GET /v1/vpn/status", "PUT /v1/vpn/status"]

--- a/test/gluetun-config/config-old.toml
+++ b/test/gluetun-config/config-old.toml
@@ -1,3 +1,4 @@
+# Used by CI for Gluetun v3.38–v3.40.0 (bind-mounted config.toml; see Makefile LEGACY_GLUETUN_CONTROL_AUTH).
 [[roles]]
 name = "gluetrans"
 routes = ["GET /v1/openvpn/portforwarded", "GET /v1/openvpn/status", "PUT /v1/openvpn/status"]

--- a/test/run-debug-test.sh
+++ b/test/run-debug-test.sh
@@ -3,7 +3,7 @@
 # Test that DEBUG=1 mode works correctly and keeps sensitive vars visible
 
 SERVICE_NAME="gluetrans"
-COMPOSE_FILE="test/docker-compose-build-debug.yaml"
+COMPOSE_FILE="${GLUETRANS_COMPOSE_DEBUG_FILE:-test/docker-compose-build-debug.yaml}"
 
 check_docker_logs() {
     test_name=$1

--- a/test/run-smoke.sh
+++ b/test/run-smoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SERVICE_NAME="gluetrans" # as in docker-compose.yml
-COMPOSE_FILE="test/docker-compose-build.yaml"
+COMPOSE_FILE="${GLUETRANS_COMPOSE_FILE:-test/docker-compose-build.yaml}"
 
 check_docker_logs() {
     test_name=$1


### PR DESCRIPTION
## Summary
Implements the approach from [issue #92](https://github.com/miklosbagi/gluetrans/issues/92): configure Gluetun control-server API key auth with **`HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE`** (JSON) instead of bind-mounting `config.toml` when Gluetun supports it ([Gluetun wiki — Configuration](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#configuration)).

## Behaviour
- **Gluetun v3.41.0+ and `latest` (CI):** `test/docker-compose-build.yaml` / debug variant set `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` on gluetun; no `config.toml` volume.
- **Gluetun v3.38–v3.40.0:** `HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE` is not available before v3.41.0 — CI uses new **`docker-compose-build-legacy-gluetun.yaml`** (and debug twin) with the previous bind-mounted `config.toml` + `config-old.toml` copy, selected via `Makefile` `LEGACY_GLUETUN_CONTROL_AUTH`.
- **`run-smoke.sh` / `run-debug-test.sh`:** read compose path from `GLUETRANS_COMPOSE_FILE` / `GLUETRANS_COMPOSE_DEBUG_FILE` exported by Make.

## Docs
- **README.md** and **DOCKERHUB_README.md:** compose examples updated; optional `config.toml` section retitled and clarified.
- **test/README.md:** describes the two compose paths.

Closes #92.