### PR TITLE
ci(docker-pr): fix skipped dev builds when Docker Hub secrets exist

### DIFF
--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -13,12 +13,11 @@
 #
 # Production v* and :latest are pushed by docker-release.yml when you push a semver tag after merge.
 #
-# Required repository secrets (Settings → Secrets and variables → Actions):
-#   DOCKERHUB_USERNAME
-#   DOCKERHUB_TOKEN      (Docker Hub access token / PAT with read & write)
+# Docker Hub secrets must be set as repository secrets (Settings → Actions). They are checked in
+# the first workflow step — do **not** gate the job on `secrets.*` in job-level `if` (GitHub can skip
+# the job even when secrets exist on `pull_request`, so you would see no dev image and no error).
 #
-# If DOCKERHUB_USERNAME or DOCKERHUB_TOKEN is unset, the build-push job is skipped so PR checks
-# still pass; add both secrets to enable dev image pushes.
+# If either secret is unset, the first step fails with a clear error (no silent skip).
 #
 # GHCR: GitHub forbids *naming* a repo secret GITHUB_* (reserved prefix). Use GH_TOKEN
 # for a PAT with write:packages (classic) or "Contents: read" + "Packages: write"
@@ -67,14 +66,23 @@ concurrency:
 jobs:
   build-push:
     if: |
-      secrets.DOCKERHUB_USERNAME != '' &&
-      secrets.DOCKERHUB_TOKEN != '' &&
-      ((github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false) ||
-      (github.event_name == 'workflow_dispatch'))
+      (github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
+      - name: Require Docker Hub repository secrets
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo '::error::Set repository secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (Settings → Secrets and variables → Actions) for Docker (PR) dev image pushes to Docker Hub and GHCR.'
+            exit 1
+          fi
+
       - name: Resolve PR head SHA
         id: head
         env:


### PR DESCRIPTION
## Problem
The **Docker (PR)** workflow’s `build-push` job used:

```yaml
if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && …
```

On `pull_request`, that pattern can cause the **entire job to be skipped** even when both Docker Hub secrets **are** configured on the repo — so PRs get **no dev image** and **no obvious failure** (the run can look “green” with a skipped job, or easy to miss).

## Fix
- Remove `secrets.*` from **job-level** `if` (only same-repo, non-draft PR / `workflow_dispatch`).
- Add a first step **Require Docker Hub repository secrets** that fails with `::error::` if either secret is empty.

After merge, pushes to PRs targeting `main` should reliably run **Docker (PR)** and publish dev tags (subject to draft/fork rules and valid secrets).

Related discussion: PR dev images not appearing despite workflow triggers.